### PR TITLE
ISA fixes for c3

### DIFF
--- a/t/actual.t
+++ b/t/actual.t
@@ -5,21 +5,25 @@ my $order = 0;
 
 package A;
 @ISA = qw/B C D/;
+use mro 'dfs';
 
 sub test { ++$order; ::ok($order==1,"test A"); $_[0]->NEXT::ACTUAL::test;}
 
 package B;
 @ISA = qw/D C/;
+use mro 'dfs';
 sub test { ++$order; ::ok($order==2,"test B"); $_[0]->NEXT::ACTUAL::test;}
 
 package C;
 @ISA = qw/D/;
+use mro 'dfs';
 sub test {
 	++$order; ::ok($order==4||$order==6,"test C");
 	$_[0]->NEXT::ACTUAL::test;
 }
 
 package D;
+use mro 'dfs';
 
 sub test {
 	++$order; ::ok($order==3||$order==5||$order==7||$order==8,"test D");
@@ -27,6 +31,7 @@ sub test {
 }
 
 package main;
+use mro 'dfs';
 
 my $foo = {};
 

--- a/t/actuns.t
+++ b/t/actuns.t
@@ -5,18 +5,22 @@ my $order = 0;
 
 package A;
 @ISA = qw/B C D/;
+use mro 'dfs';
 
 sub test { ::ok(++$order==1,"test A"); $_[0]->NEXT::UNSEEN::ACTUAL::test;}
 
 package B;
 @ISA = qw/D C/;
+use mro 'dfs';
 sub test { ::ok(++$order==2,"test B"); $_[0]->NEXT::ACTUAL::UNSEEN::test;}
 
 package C;
 @ISA = qw/D/;
+use mro 'dfs';
 sub test { ::ok(++$order==4,"test C"); $_[0]->NEXT::UNSEEN::ACTUAL::test;}
 
 package D;
+use mro 'dfs';
 
 sub test { ::ok(++$order==3,"test D"); $_[0]->NEXT::ACTUAL::UNSEEN::test;}
 

--- a/t/unseen.t
+++ b/t/unseen.t
@@ -5,22 +5,27 @@ my $order = 0;
 
 package A;
 @ISA = qw/B C D/;
+use mro 'dfs';
 
 sub test { ::ok(++$order==1,"test A"); $_[0]->NEXT::UNSEEN::test; 1}
 
 package B;
 @ISA = qw/D C/;
+use mro 'dfs';
 sub test { ::ok(++$order==2,"test B"); $_[0]->NEXT::UNSEEN::test; 1}
 
 package C;
 @ISA = qw/D/;
+use mro 'dfs';
 sub test { ::ok(++$order==4,"test C"); $_[0]->NEXT::UNSEEN::test; 1}
 
 package D;
+use mro 'dfs';
 
 sub test { ::ok(++$order==3,"test D"); $_[0]->NEXT::UNSEEN::test; 1}
 
 package main;
+use mro 'dfs';
 
 my $foo = {};
 
@@ -31,6 +36,7 @@ eval{ $foo->test }
 	: fail("Shouldn't die on missing ancestor");
 
 package Diamond::Base;
+use mro 'dfs';
 my $seen;
 sub test {
 	$seen++ ? ::fail("Can't visit inherited test twice")
@@ -39,8 +45,11 @@ sub test {
 }
 
 package Diamond::Left;  @ISA = qw[Diamond::Base];
+use mro 'dfs';
 package Diamond::Right; @ISA = qw[Diamond::Base];
+use mro 'dfs';
 package Diamond::Top;   @ISA = qw[Diamond::Left Diamond::Right];
+use mro 'dfs';
 
 package main;
 


### PR DESCRIPTION
use mro dfs explicitly, otherwise it fails
on perls which do use c3 as default (cperl).
later we will need to add extra c3 tests.