### PR TITLE
remove dependency on mro

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,7 +17,6 @@ my @TEST_REQUIRES = (
     'Test::More'    => 0.88,
     'constant'      => 0,
     'base'          => 0,
-    'mro'           => 0,
 );
 
 push(@REQUIRES, @TEST_REQUIRES) if $mm_ver < 6.64;


### PR DESCRIPTION
mro is only used in tests on perl versions that include it in core.
Listing it as a prereq makes it impossible to install this module on
older perl versions where it wouldn't be used anyway. It would be
possible to conditionally list it as a prereq, but since mro is core
only, this serves little purpose and is extra complexity.