### PR TITLE
only install in perl dirs on older perls with bad load order

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,7 @@ WriteMakefile(
     NAME         => q[NEXT],
     VERSION_FROM => q[lib/NEXT.pm],
     PREREQ_PM   => { @REQUIRES },
-    INSTALLDIRS  => $] >= 5.007003 ? 'perl' : 'site',
+    INSTALLDIRS  => ($] >= 5.007003 && $] < 5.011) ? 'perl' : 'site',
 
     ($mm_ver >= 6.64
         ? (TEST_REQUIRES => { @TEST_REQUIRES })


### PR DESCRIPTION
perl was fixed in 5.12 to have site come before perl in `@INC`, so there
is no need to instal in perl on newer versions.